### PR TITLE
feat: upgrade `@gitlab/svgs` to v2.12.0

### DIFF
--- a/ICON_INDEX.md
+++ b/ICON_INDEX.md
@@ -1,6 +1,6 @@
 # Icon Index
 
-> 370 total icons
+> 378 total icons
 
 ## Icons
 
@@ -122,6 +122,8 @@
 - ExternalLink
 - EyeSlash
 - Eye
+- FaceNeutral
+- FaceUnhappy
 - FalsePositive
 - FeatureFlagDisabled
 - FeatureFlag
@@ -142,6 +144,7 @@
 - Folder
 - Food
 - Fork
+- Formula
 - GitMerge
 - Git
 - Github
@@ -276,6 +279,7 @@
 - SeverityUnknown
 - Share
 - Shield
+- Sidebar
 - Skype
 - SlightFrown
 - SlightSmile
@@ -335,7 +339,9 @@
 - Stop
 - Strikethrough
 - Subgroup
+- Subscript
 - Substitute
+- Superscript
 - Symlink
 - Table
 - Tablet
@@ -353,6 +359,7 @@
 - Thumbtack
 - TimeOut
 - Timer
+- Title
 - TodoAdd
 - TodoDone
 - Token
@@ -366,6 +373,7 @@
 - Underline
 - Unlink
 - UnstageAll
+- Upgrade
 - Upload
 - User
 - Users

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "svelte-check --workspace test"
   },
   "devDependencies": {
-    "@gitlab/svgs": "2.12.0",
+    "@gitlab/svgs": "2.27.0",
     "gh-pages": "^4.0.0",
     "rollup": "^2.76.0",
     "svelte": "^3.49.0",

--- a/test/Icons.test.svelte
+++ b/test/Icons.test.svelte
@@ -5,6 +5,7 @@
     Connected,
     AttentionSolid,
     LicenseSm,
+    FaceNeutral
   } from "../lib";
   import Api from "../lib/Api.svelte";
 </script>
@@ -15,3 +16,4 @@
 <Connected />
 <AttentionSolid />
 <LicenseSm fill="red" />
+<FaceNeutral />

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,10 +23,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@gitlab/svgs@2.12.0":
-  version "2.12.0"
-  resolved "https://registry.yarnpkg.com/@gitlab/svgs/-/svgs-2.12.0.tgz#f4825c3e9b95d219935b62f71143f9f2fc48b0fe"
-  integrity sha512-FHd0ImNyj8ZIiH3Ah2esxbxNQlXMSezqkcUe0nm+aWkSFsg6MbMcRYa6WvOKq5CbAgWpH1TbDqokkJ421YUtEg==
+"@gitlab/svgs@2.27.0":
+  version "2.27.0"
+  resolved "https://registry.yarnpkg.com/@gitlab/svgs/-/svgs-2.27.0.tgz#563aaa8e059ca50c3fd2c39e077bba4951b6c850"
+  integrity sha512-/Pc8PueTGJbQRB4AhJGyYOM3Ak09oqbXCykLU8cLd41NTbTPdvcXo7QwG76fFL83HkxrrAPJeSnbCMsme5CVKQ==
 
 "@jridgewell/resolve-uri@^3.0.3":
   version "3.1.0"


### PR DESCRIPTION
**Features**

- upgrade `@gitlab/svgs` to v2.12.0 (net +8 icons)