### PR TITLE
feat(deps): upgrade `@gitlab/svgs` to 3.1.0

### DIFF
--- a/ICON_INDEX.md
+++ b/ICON_INDEX.md
@@ -1,6 +1,6 @@
 # Icon Index
 
-> 373 total icons
+> 374 total icons
 
 ## Icons
 
@@ -171,6 +171,7 @@
 - IssueTypeIssue
 - IssueTypeMaintenance
 - IssueTypeRequirements
+- IssueTypeTask
 - IssueTypeTestCase
 - IssueUpdate
 - Issues

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "svelte-check --workspace test"
   },
   "devDependencies": {
-    "@gitlab/svgs": "3.0.0",
+    "@gitlab/svgs": "3.1.0",
     "gh-pages": "^4.0.0",
     "rollup": "^2.77.2",
     "svelte": "^3.49.0",

--- a/test/Icons.test.svelte
+++ b/test/Icons.test.svelte
@@ -7,6 +7,7 @@
     LicenseSm,
     FaceNeutral,
     LiveStream,
+    IssueTypeTask,
   } from "../lib";
   import Api from "../lib/Api.svelte";
 </script>
@@ -19,3 +20,4 @@
 <LicenseSm fill="red" />
 <FaceNeutral />
 <LiveStream />
+<IssueTypeTask />

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,10 +23,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@gitlab/svgs@3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@gitlab/svgs/-/svgs-3.0.0.tgz#e16efbbb57867d64e841b295c9da4435fdc029b4"
-  integrity sha512-ffP9qzCIIElsoRAdh2HPSdHpv9Dz0B44oRSSCpbNMXYF77Rhyv9rO4ft+wJtYyvNXZ7piFJIEvS79Tu7wkRmHQ==
+"@gitlab/svgs@3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@gitlab/svgs/-/svgs-3.1.0.tgz#0108498a17e2f79d16158015db0be764b406cc09"
+  integrity sha512-kZ45VTQOgLdwQCLRSj7+aohF+6AUnAaoucR1CFY/6DPDLnNNGeflwsCLN0sFBKwx42HLxFfNwvDmKOMLdSQg5A==
 
 "@jridgewell/gen-mapping@^0.3.0":
   version "0.3.2"


### PR DESCRIPTION
- upgrade `@gitlab/svgs` to [v3.1.0](https://gitlab.com/gitlab-org/gitlab-svgs/-/releases/v3.1.0) (net +1 icon)