### PR TITLE
feat(deps): upgrade `@gitlab/svgs` to 3.7.0

### DIFF
--- a/ICON_INDEX.md
+++ b/ICON_INDEX.md
@@ -1,6 +1,6 @@
 # Icon Index
 
-> 377 total icons
+> 379 total icons
 
 ## Icons
 
@@ -143,6 +143,7 @@
 - Formula
 - GitMerge
 - Git
+- Gitea
 - Github
 - GoBack
 - Google
@@ -150,6 +151,7 @@
 - Hamburger
 - Heading
 - Heart
+- Highlight
 - History
 - Home
 - Hook

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "svelte-check --workspace test"
   },
   "devDependencies": {
-    "@gitlab/svgs": "3.4.0",
+    "@gitlab/svgs": "3.7.0",
     "gh-pages": "^4.0.0",
     "rollup": "^2.79.1",
     "svelte": "^3.52.0",

--- a/test/Icons.test.svelte
+++ b/test/Icons.test.svelte
@@ -10,6 +10,7 @@
     IssueTypeTask,
     EntityBlocked,
     CheckSm,
+    Gitea,
   } from "../lib";
   import Api from "../lib/Api.svelte";
 </script>
@@ -25,3 +26,4 @@
 <IssueTypeTask />
 <EntityBlocked />
 <CheckSm />
+<Gitea />

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,10 +23,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@gitlab/svgs@3.4.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@gitlab/svgs/-/svgs-3.4.0.tgz#cfc8319e259e5914ad0f48ee0ab6e0eec75d03da"
-  integrity sha512-myCYbjViOI2k6oHGRqL1iKaMKbYvPqWL6tYZ07QkUKziVz5kYjECWk5c0Qp6yu9NsFAMWuow5PkR3oFTGBHmbg==
+"@gitlab/svgs@3.7.0":
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/@gitlab/svgs/-/svgs-3.7.0.tgz#1257b69fb9898ea5614f992aa6b6dc3619c3c38c"
+  integrity sha512-6vTqWZzY63ZUTUqk0dmMDcfU27qtkAu0WmlK4e3FMWmISvTxNhAk2j11c/YlLauf6okE4W2T2fnhvXp1mzcPgA==
 
 "@jridgewell/gen-mapping@^0.3.0":
   version "0.3.2"


### PR DESCRIPTION
- upgrade `@gitlab/svgs` to [v3.7.0](https://gitlab.com/gitlab-org/gitlab-svgs/-/releases/v3.7.0) (net +2 icons)