### PR TITLE
feat(deps): upgrade `@gitlab/svgs` to 3.13.0

### DIFF
--- a/ICON_INDEX.md
+++ b/ICON_INDEX.md
@@ -1,6 +1,6 @@
 # Icon Index
 
-> 379 total icons
+> 385 total icons
 
 ## Icons
 
@@ -32,6 +32,7 @@
 - Branch
 - BrandZoom
 - Bug
+- Building
 - Bulb
 - Bullhorn
 - Calendar
@@ -63,6 +64,7 @@
 - Code
 - CollapseLeft
 - CollapseRight
+- CollapseSolid
 - Collapse
 - CommentDots
 - CommentNext
@@ -70,6 +72,7 @@
 - Comments
 - Commit
 - Comparison
+- Compass
 - Connected
 - ContainerImage
 - CopyToClipboard
@@ -173,7 +176,9 @@
 - IssueTypeFeature
 - IssueTypeIncident
 - IssueTypeIssue
+- IssueTypeKeyResult
 - IssueTypeMaintenance
+- IssueTypeObjective
 - IssueTypeRequirements
 - IssueTypeTask
 - IssueTypeTestCase
@@ -250,6 +255,7 @@
 - PushRules
 - QuestionO
 - Question
+- Quota
 - Quote
 - Redo
 - RemoveAll

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "svelte-check --workspace test"
   },
   "devDependencies": {
-    "@gitlab/svgs": "3.7.0",
+    "@gitlab/svgs": "3.13.0",
     "gh-pages": "^4.0.0",
     "rollup": "^2.79.1",
     "svelte": "^3.54.0",

--- a/test/Icons.test.svelte
+++ b/test/Icons.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import {
+    Building,
     Fire,
     MergeRequestOpen,
     Connected,
@@ -15,6 +16,7 @@
   import Api from "../lib/Api.svelte";
 </script>
 
+<Building />
 <Fire />
 <MergeRequestOpen />
 <Api width="30" />

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,10 +23,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@gitlab/svgs@3.7.0":
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/@gitlab/svgs/-/svgs-3.7.0.tgz#1257b69fb9898ea5614f992aa6b6dc3619c3c38c"
-  integrity sha512-6vTqWZzY63ZUTUqk0dmMDcfU27qtkAu0WmlK4e3FMWmISvTxNhAk2j11c/YlLauf6okE4W2T2fnhvXp1mzcPgA==
+"@gitlab/svgs@3.13.0":
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/@gitlab/svgs/-/svgs-3.13.0.tgz#2d62286c956bd49ba7156b2aa4eed79507baca53"
+  integrity sha512-Yv4dZ4pOyUVMCZXNxLuMinZ/x8E6+g8/yM1z/2ERT0t7hSAC3bCUHn2OEFpujtYzFtwMZXMFPQFEJJipQ1I/+w==
 
 "@jridgewell/gen-mapping@^0.3.0":
   version "0.3.2"


### PR DESCRIPTION
- upgrade `@gitlab/svgs` to [v3.13.0](https://gitlab.com/gitlab-org/gitlab-svgs/-/releases/v3.13.0) (net +6 icons)