### PR TITLE
feat(deps)!: upgrade `@gitlab/svgs` to 3.17.0

### DIFF
--- a/ICON_INDEX.md
+++ b/ICON_INDEX.md
@@ -1,6 +1,6 @@
 # Icon Index
 
-> 385 total icons
+> 389 total icons
 
 ## Icons
 
@@ -81,6 +81,7 @@
 - Dashboard
 - Deployments
 - DetailsBlock
+- Discord
 - Disk
 - DocChanges
 - DocChart
@@ -150,6 +151,7 @@
 - Github
 - GoBack
 - Google
+- Grip
 - Group
 - Hamburger
 - Heading
@@ -176,7 +178,7 @@
 - IssueTypeFeature
 - IssueTypeIncident
 - IssueTypeIssue
-- IssueTypeKeyResult
+- IssueTypeKeyresult
 - IssueTypeMaintenance
 - IssueTypeObjective
 - IssueTypeRequirements
@@ -187,6 +189,7 @@
 - Italic
 - Iteration
 - Key
+- Keyboard
 - KubernetesAgent
 - Kubernetes
 - Label
@@ -275,6 +278,7 @@
 - SearchDot
 - SearchMinus
 - SearchPlus
+- SearchResults
 - SearchSm
 - Search
 - Settings

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "svelte-check --workspace test"
   },
   "devDependencies": {
-    "@gitlab/svgs": "3.13.0",
+    "@gitlab/svgs": "3.17.0",
     "gh-pages": "^4.0.0",
     "rollup": "^2.79.1",
     "svelte": "^3.54.0",

--- a/test/Icons.test.svelte
+++ b/test/Icons.test.svelte
@@ -12,6 +12,7 @@
     EntityBlocked,
     CheckSm,
     Gitea,
+    Discord,
   } from "../lib";
   import Api from "../lib/Api.svelte";
 </script>
@@ -29,3 +30,4 @@
 <EntityBlocked />
 <CheckSm />
 <Gitea />
+<Discord />

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,10 +23,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@gitlab/svgs@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@gitlab/svgs/-/svgs-3.13.0.tgz#2d62286c956bd49ba7156b2aa4eed79507baca53"
-  integrity sha512-Yv4dZ4pOyUVMCZXNxLuMinZ/x8E6+g8/yM1z/2ERT0t7hSAC3bCUHn2OEFpujtYzFtwMZXMFPQFEJJipQ1I/+w==
+"@gitlab/svgs@3.17.0":
+  version "3.17.0"
+  resolved "https://registry.yarnpkg.com/@gitlab/svgs/-/svgs-3.17.0.tgz#beeda4bd2b97ec2637bebe1760dbe283d6a599ef"
+  integrity sha512-+5wsh/FG7SSkUQjehROl+0nRgrg/XRNUa9h3LkxpksP0AXy4j6xuYuq+7xucDGJDdXo43tUftLc9w7u/SCmgQA==
 
 "@jridgewell/gen-mapping@^0.3.0":
   version "0.3.2"


### PR DESCRIPTION
- `IssueTypeKeyResult` renamed to `IssueTypeKeyresult`
- upgrade `@gitlab/svgs` to [v3.17.0](https://gitlab.com/gitlab-org/gitlab-svgs/-/releases/v3.17.0) (net +4 icons)