### PR TITLE
feat(deps): upgrade `@gitlab/svgs` to 3.19.0

### DIFF
--- a/ICON_INDEX.md
+++ b/ICON_INDEX.md
@@ -1,6 +1,6 @@
 # Icon Index
 
-> 389 total icons
+> 391 total icons
 
 ## Icons
 
@@ -81,6 +81,7 @@
 - Dashboard
 - Deployments
 - DetailsBlock
+- Diagram
 - Discord
 - Disk
 - DocChanges
@@ -269,6 +270,7 @@
 - ReviewCheckmark
 - ReviewList
 - ReviewWarning
+- RocketLaunch
 - Rocket
 - Rss
 - Scale

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "svelte-check --workspace test"
   },
   "devDependencies": {
-    "@gitlab/svgs": "3.17.0",
+    "@gitlab/svgs": "3.19.0",
     "gh-pages": "^4.0.0",
     "rollup": "^2.79.1",
     "svelte": "^3.54.0",

--- a/test/Icons.test.svelte
+++ b/test/Icons.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import {
+    Diagram,
     Building,
     Fire,
     MergeRequestOpen,
@@ -17,6 +18,7 @@
   import Api from "../lib/Api.svelte";
 </script>
 
+<Diagram />
 <Building />
 <Fire />
 <MergeRequestOpen />

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,10 +23,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@gitlab/svgs@3.17.0":
-  version "3.17.0"
-  resolved "https://registry.yarnpkg.com/@gitlab/svgs/-/svgs-3.17.0.tgz#beeda4bd2b97ec2637bebe1760dbe283d6a599ef"
-  integrity sha512-+5wsh/FG7SSkUQjehROl+0nRgrg/XRNUa9h3LkxpksP0AXy4j6xuYuq+7xucDGJDdXo43tUftLc9w7u/SCmgQA==
+"@gitlab/svgs@3.19.0":
+  version "3.19.0"
+  resolved "https://registry.yarnpkg.com/@gitlab/svgs/-/svgs-3.19.0.tgz#23bfe338708d62a310fe424693455339baa6cac1"
+  integrity sha512-R/nWQXTpN1Vf8FwxgSODK2f2cU6fsmb7Y2pOLozUPYACKRqJkEwD0Bv7nzWsgheEO/fMK9olv83R9v0acYYI/A==
 
 "@jridgewell/gen-mapping@^0.3.0":
   version "0.3.2"


### PR DESCRIPTION
- upgrade `@gitlab/svgs` to [v3.19.0](https://gitlab.com/gitlab-org/gitlab-svgs/-/releases/v3.19.0) (net +2 icons)