### PR TITLE
feat(deps): upgrade `@gitlab/svgs` to 3.51.0

### DIFF
--- a/ICON_INDEX.md
+++ b/ICON_INDEX.md
@@ -1,6 +1,6 @@
 # Icon Index
 
-> 391 total icons
+> 400 total icons
 
 ## Icons
 
@@ -61,12 +61,15 @@
 - Clock
 - Close
 - CloudGear
+- CloudPod
+- CloudTerminal
 - Code
 - CollapseLeft
 - CollapseRight
 - CollapseSolid
 - Collapse
 - CommentDots
+- CommentLines
 - CommentNext
 - Comment
 - Comments
@@ -213,6 +216,8 @@
 - LongArrow
 - MachineLearning
 - Mail
+- MarkdownMarkSolid
+- MarkdownMark
 - MarqueeSelection
 - Maximize
 - MediaBroken
@@ -234,6 +239,7 @@
 - NotificationsOff
 - Notifications
 - Object
+- Organization
 - Overview
 - Package
 - PaperAirplane
@@ -257,12 +263,14 @@
 - PushRules
 - QuestionO
 - Question
+- QuickActions
 - Quota
 - Quote
 - Redo
 - RemoveAll
 - Remove
 - Repeat
+- Reply
 - Requirements
 - Retry
 - ReviewCheckmark
@@ -359,6 +367,7 @@
 - Tablet
 - Tachometer
 - Tag
+- TanukiAi
 - TanukiVerified
 - Tanuki
 - TaskDone

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "svelte-check --workspace test"
   },
   "devDependencies": {
-    "@gitlab/svgs": "3.24.0",
+    "@gitlab/svgs": "3.51.0",
     "gh-pages": "^4.0.0",
     "rollup": "^2.79.1",
     "svelte": "^3.54.0",

--- a/test/Icons.test.svelte
+++ b/test/Icons.test.svelte
@@ -15,6 +15,7 @@
     Gitea,
     Discord,
     MachineLearning,
+    CloudPod,
   } from "../lib";
   import Api from "../lib/Api.svelte";
 </script>
@@ -35,3 +36,4 @@
 <Gitea />
 <Discord />
 <MachineLearning />
+<CloudPod />

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,10 +23,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@gitlab/svgs@3.24.0":
-  version "3.24.0"
-  resolved "https://registry.yarnpkg.com/@gitlab/svgs/-/svgs-3.24.0.tgz#bc8265919aa04b06cd08be91637471bad195936d"
-  integrity sha512-R4s5qJUFUIbPflknpw1aI/PchiNq65vY7LVsJZnQkY+vi+AgmsETdut/AdferbGWmeWMU0q2wuVu9phE8lDUgA==
+"@gitlab/svgs@3.51.0":
+  version "3.51.0"
+  resolved "https://registry.yarnpkg.com/@gitlab/svgs/-/svgs-3.51.0.tgz#c6d63c7e16b71b167662696662efc1b0587acaaf"
+  integrity sha512-IyMcZsLJ7AYoyHhWimHKsP/Swk0MlOLxHxgP9kp8Nc/xPC8p/JRVzlWU9vehSTcoYzu55alnKYABJe4fhUw2aQ==
 
 "@jridgewell/gen-mapping@^0.3.0":
   version "0.3.2"


### PR DESCRIPTION
- upgrade `@gitlab/svgs` to [v3.51.0](https://gitlab.com/gitlab-org/gitlab-svgs/-/releases/v3.51.0) (net +9 icons)