### PR TITLE
feat(deps): upgrade `@gitlab/svgs` to 3.54.0

### DIFF
--- a/ICON_INDEX.md
+++ b/ICON_INDEX.md
@@ -1,6 +1,6 @@
 # Icon Index
 
-> 400 total icons
+> 401 total icons
 
 ## Icons
 
@@ -39,6 +39,7 @@
 - Cancel
 - CanceledCircle
 - Car
+- CatalogCheckmark
 - Chart
 - CheckCircleDashed
 - CheckCircleFilled

--- a/package.json
+++ b/package.json
@@ -15,13 +15,13 @@
     "test": "svelte-check --workspace test"
   },
   "devDependencies": {
-    "@gitlab/svgs": "3.51.0",
+    "@gitlab/svgs": "3.54.0",
     "gh-pages": "^4.0.0",
     "rollup": "^2.79.1",
-    "svelte": "^3.54.0",
+    "svelte": "^3.59.2",
     "svelte-check": "^2.10.1",
     "svelte-readme": "^3.6.3",
-    "svelvg": "^0.11.3"
+    "svelvg": "^0.12.1"
   },
   "repository": {
     "type": "git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,10 +23,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@gitlab/svgs@3.51.0":
-  version "3.51.0"
-  resolved "https://registry.yarnpkg.com/@gitlab/svgs/-/svgs-3.51.0.tgz#c6d63c7e16b71b167662696662efc1b0587acaaf"
-  integrity sha512-IyMcZsLJ7AYoyHhWimHKsP/Swk0MlOLxHxgP9kp8Nc/xPC8p/JRVzlWU9vehSTcoYzu55alnKYABJe4fhUw2aQ==
+"@gitlab/svgs@3.54.0":
+  version "3.54.0"
+  resolved "https://registry.yarnpkg.com/@gitlab/svgs/-/svgs-3.54.0.tgz#6002ed7b3c2db832bef34629d6d5677ac36c45d6"
+  integrity sha512-Fvo/0lF/Gx+na21Qg4qr02EsP1OEhVlkuh8ctmHMLu5cr5ho3b/MZYLHLjI8F5FDkTIpennyYuhxqiU8kTVM2Q==
 
 "@jridgewell/gen-mapping@^0.3.0":
   version "0.3.2"
@@ -1100,22 +1100,17 @@ svelte-readme@^3.6.3:
     rollup-plugin-svelte "^7.0.0"
     rollup-plugin-terser "^7.0.2"
 
-svelte@^3.50.1:
-  version "3.50.1"
-  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.50.1.tgz#b35fbc5e79ddd71e8bb27c3149ee6ff903841239"
-  integrity sha512-bS4odcsdj5D5jEg6riZuMg5NKelzPtmsCbD9RG+8umU03TeNkdWnP6pqbCm0s8UQNBkqk29w/Bdubn3C+HWSwA==
+svelte@^3.59.1, svelte@^3.59.2:
+  version "3.59.2"
+  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.59.2.tgz#a137b28e025a181292b2ae2e3dca90bf8ec73aec"
+  integrity sha512-vzSyuGr3eEoAtT/A6bmajosJZIUWySzY2CzB3w2pgPvnkUjGqlDnsNnA0PMO+mMAhuyMul6C2uuZzY6ELSkzyA==
 
-svelte@^3.54.0:
-  version "3.54.0"
-  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.54.0.tgz#b4bcd865bd9e927f9f7b76563288ef5f4d72867a"
-  integrity sha512-tdrgeJU0hob0ZWAMoKXkhcxXA7dpTg6lZGxUeko5YqvPdJBiyRspGsCwV27kIrbrqPP2WUoSV9ca0gnLlw8YzQ==
-
-svelvg@^0.11.3:
-  version "0.11.3"
-  resolved "https://registry.yarnpkg.com/svelvg/-/svelvg-0.11.3.tgz#63905c76d5a4296866c041f1ea1546ea4666728c"
-  integrity sha512-E56Fv4D1+noE9q4wCEGElRXhpFV1pgsXbVO2vNSOuldDtYnere2fMJ5J5L+Zb7qu5nYM9u/7rwZ1/CGlb2rzmQ==
+svelvg@^0.12.1:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/svelvg/-/svelvg-0.12.1.tgz#87495da7c9666a68195e7c5a3467c118f21bcd50"
+  integrity sha512-YGAQSR6iCseN6w3R8EP2tvwKlGjT2812knSbK3hunnBjoe+rgorD/LrzdjkBq1mP6Y3dG6vOyE9jW6Vl+xkLxg==
   dependencies:
-    svelte "^3.50.1"
+    svelte "^3.59.1"
     tiny-glob "^0.2.9"
 
 terser@^5.0.0:


### PR DESCRIPTION
**Breaking Changes**

- minimum Svelte version for TS users is 3.55 since generated type definitions now use `svelte/elements`

**Features**

- upgrade `@gitlab/svgs` to [v3.54.0](https://gitlab.com/gitlab-org/gitlab-svgs/-/releases/v3.54.0) (net +1 icon)

**Fixes**

- allow `data-*` attributes to be passed to icon components